### PR TITLE
chore: add fossa github action job

### DIFF
--- a/.fossa.yaml
+++ b/.fossa.yaml
@@ -1,0 +1,9 @@
+version: 3
+
+server: https://app.fossa.com
+
+project:
+  id: github.com/openfga/spring-boot-starter
+  name: openfga/spring-boot-starter
+  link: openfga.dev
+  url: https://github.com/openfga/spring-boot-starter

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -23,7 +23,6 @@ jobs:
         uses: fossas/fossa-action@main
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
-          project: spring-boot-starter
           run-tests: true
   build:
     name: Run Checks


### PR DESCRIPTION
<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->

Adds fossa GitHub actions job to the CI workflow.

Configuration is similar to https://www.github.com/openfga/js-sdk/commit/10e06b3360acd8a20841fe8e0989a32d5f573348

## References
<!-- Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..) -->

https://app.fossa.com/projects/git%2Bgithub.com%2Fopenfga%2Fspring-boot-starter/

## Review Checklist
- [x] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [x] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected
