### PR TITLE
Add Testcontainers Service Connection in examples

### DIFF
--- a/examples/servlet/README.md
+++ b/examples/servlet/README.md
@@ -14,18 +14,9 @@ To use a different FGA server, update `src/main/resources/application.yaml` acco
 
 ## Usage
 
-### Start OpenFGA server
-
-In a terminal, start the OpenFGA Server:
-
-```bash
-docker pull openfga/openfga:latest
-docker run --rm -e OPENFGA_HTTP_ADDR=0.0.0.0:4000 -p 4000:4000 -p 8081:8081 -p 3000:3000 openfga/openfga run
-```
-
 ### Start the example application:
 
-In a separate terminal, start the application:
+In a terminal, start the application:
 
 ```bash
 ./gradlew bootRun

--- a/examples/servlet/build.gradle
+++ b/examples/servlet/build.gradle
@@ -20,4 +20,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     implementation 'dev.openfga:openfga-spring-boot-starter:0.0.1'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:openfga:1.20.0'
 }

--- a/examples/servlet/src/test/java/dev/openfga/example/TestServletApp.java
+++ b/examples/servlet/src/test/java/dev/openfga/example/TestServletApp.java
@@ -1,0 +1,28 @@
+package dev.openfga.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.testcontainers.openfga.OpenFGAContainer;
+
+public class TestServletApp {
+
+    public static void main(String[] args) {
+        SpringApplication.from(ServletApp::main)
+                .with(TestConfig.class)
+                .run(args);
+    }
+
+    @TestConfiguration(proxyBeanMethods = false)
+    static class TestConfig {
+
+        @Bean
+        OpenFGAContainer container(DynamicPropertyRegistry registry) {
+            OpenFGAContainer container = new OpenFGAContainer("openfga/openfga:v1.4.3");
+            registry.add("openfga.api-url", container::getHttpEndpoint);
+            return container;
+        }
+
+    }
+}

--- a/examples/servlet/src/test/resources/logback-test.xml
+++ b/examples/servlet/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+</configuration>


### PR DESCRIPTION
Use Testcontainers OpenFGA Module to improve DevEx when starting the example.

This is an alternative solution for #58 due to the current state of the project. I'm planning to add another PRs to add native integration where the DynamicPropertyRegistry is not needed.