### PR TITLE
chore(ci): grant write access to job publishing github pkg

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -101,6 +101,9 @@ jobs:
     needs: [ publish-maven-central, publish-github-packages ]
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/spring-boot-starter/security/code-scanning/6](https://github.com/openfga/spring-boot-starter/security/code-scanning/6)

To fix the problem, add a `permissions` block to the `create-release` job in `.github/workflows/main.yaml`. This block should grant only the minimum permissions required for the job to function. Since the job uses the `github-create-release-action` to create a release, it needs `contents: write` permission. The `test` job does not appear to require any write permissions, so it could be set to `contents: read` for defense in depth, but the CodeQL finding is specifically about the `create-release` job. The fix involves inserting the following under the `create-release:` job definition (at the same indentation as `runs-on`):

```yaml
permissions:
  contents: write
```

No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
