### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Run Checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/spring-boot-starter/security/code-scanning/4](https://github.com/openfga/spring-boot-starter/security/code-scanning/4)

To fix the problem, add a `permissions` block to the `test` job in `.github/workflows/main.yaml`, specifying the least privilege required. Since the job only checks out code and runs tests, it only needs read access to repository contents. The change should be made directly under the `runs-on` key for the `test` job (after line 12), adding:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
