### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -1,4 +1,6 @@
 name: FOSSA
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/openfga/spring-boot-starter/security/code-scanning/3](https://github.com/openfga/spring-boot-starter/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow or the specific job. The minimal required permission for most read-only actions is `contents: read`. This should be added at the top level of the workflow (just after the `name:` and before `on:`), so it applies to all jobs unless overridden. No changes to the steps or other workflow logic are needed. The edit should be made to `.github/workflows/fossa.yaml`, inserting the following lines:

```yaml
permissions:
  contents: read
```

immediately after the `name: FOSSA` line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
