### PR TITLE
chore: upgrade gradle/actions from v5.0.2 to v6.1.0 with basic cache provider

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       day: "monday"
     ignore:
       - dependency-name: "gradle/actions/setup-gradle"
-        versions: [">= 6.0.0, < 7.0.0"]
+        versions: [">= 6.0.0, < 6.1.0"]
     groups:
       dependencies:
         patterns:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,8 +27,11 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: "temurin"
 
+      # Use the open-source basic cache provider
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-provider: basic
 
       - name: Run Gradle check task
         run: ./gradlew check --continue
@@ -51,8 +54,11 @@ jobs:
           java-version: 17
           distribution: "temurin"
 
+      # Use the open-source basic cache provider
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-provider: basic
 
       - name: Publish package
         # Tasks created by https://github.com/gradle-nexus/publish-plugin
@@ -81,8 +87,11 @@ jobs:
           java-version: 17
           distribution: "temurin"
 
+      # Use the open-source basic cache provider
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+        with:
+          cache-provider: basic
 
       - name: Publish package
         # Tasks created by https://docs.gradle.org/current/userguide/publishing_maven.html


### PR DESCRIPTION
Upgrades gradle/actions/setup-gradle to v6.1.0 across all workflow jobs and switches to the open-source basic cache provider, avoiding reliance on the Gradle Build Scan service for caching.

Also narrows the dependabot ignore range from >= 6.0.0, < 7.0.0 to >= 6.0.0, < 6.1.0 so future v6.x patch releases are picked up automatically.

Mirrors the change applied in openfga/java-sdk#318.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline tooling to enable more frequent dependency updates and improved build caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->