### PR TITLE
fix: support Spring Boot 4 by dropping removed PropertyMapper APIs

### DIFF
--- a/src/main/java/dev/openfga/autoconfigure/OpenFgaAutoConfiguration.java
+++ b/src/main/java/dev/openfga/autoconfigure/OpenFgaAutoConfiguration.java
@@ -13,6 +13,7 @@ import dev.openfga.sdk.api.configuration.*;
 import dev.openfga.sdk.errors.FgaInvalidParameterException;
 import java.net.http.HttpClient;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.openapitools.jackson.nullable.JsonNullableModule;
@@ -48,7 +49,7 @@ public class OpenFgaAutoConfiguration {
         var clientConfiguration = new ClientConfiguration();
         var map = PropertyMapper.get();
         map.from(openFgaProperties::getCredentials)
-                .whenNonNull()
+                .when(Objects::nonNull)
                 .as(OpenFgaAutoConfiguration::toCredentials)
                 .to(clientConfiguration::credentials);
         map.from(openFgaProperties::getApiUrl).whenHasText().to(clientConfiguration::apiUrl);
@@ -57,13 +58,15 @@ public class OpenFgaAutoConfiguration {
                 .whenHasText()
                 .to(clientConfiguration::authorizationModelId);
         map.from(openFgaProperties::getUserAgent).whenHasText().to(clientConfiguration::userAgent);
-        map.from(openFgaProperties::getReadTimeout).whenNonNull().to(clientConfiguration::readTimeout);
-        map.from(openFgaProperties::getConnectTimeout).whenNonNull().to(clientConfiguration::connectTimeout);
-        map.from(openFgaProperties::getMaxRetries).whenNonNull().to(clientConfiguration::maxRetries);
-        map.from(openFgaProperties::getMinimumRetryDelay).whenNonNull().to(clientConfiguration::minimumRetryDelay);
-        map.from(openFgaProperties::getDefaultHeaders).whenNonNull().to(clientConfiguration::defaultHeaders);
+        map.from(openFgaProperties::getReadTimeout).when(Objects::nonNull).to(clientConfiguration::readTimeout);
+        map.from(openFgaProperties::getConnectTimeout).when(Objects::nonNull).to(clientConfiguration::connectTimeout);
+        map.from(openFgaProperties::getMaxRetries).when(Objects::nonNull).to(clientConfiguration::maxRetries);
+        map.from(openFgaProperties::getMinimumRetryDelay)
+                .when(Objects::nonNull)
+                .to(clientConfiguration::minimumRetryDelay);
+        map.from(openFgaProperties::getDefaultHeaders).when(Objects::nonNull).to(clientConfiguration::defaultHeaders);
         map.from(openFgaProperties::getTelemetryConfiguration)
-                .whenNonNull()
+                .when(Objects::nonNull)
                 .as(OpenFgaAutoConfiguration::toTelemetryConfiguration)
                 .to(clientConfiguration::telemetryConfiguration);
         return clientConfiguration;

--- a/src/main/java/dev/openfga/autoconfigure/OpenFgaProperties.java
+++ b/src/main/java/dev/openfga/autoconfigure/OpenFgaProperties.java
@@ -209,7 +209,7 @@ public class OpenFgaProperties implements InitializingBean {
      *
      * @return the maximum number of retries
      */
-    public int getMaxRetries() {
+    public Integer getMaxRetries() {
         return maxRetries;
     }
 


### PR DESCRIPTION
Fixes #145.

- Replace removed `PropertyMapper.Source#whenNonNull()` with `when(Objects::nonNull)` (works on both Boot 3 and Boot 4).
- Change `OpenFgaProperties#getMaxRetries` from `int` to `Integer`. The field is nullable; the primitive getter NPEs on auto-unbox when `openfga.max-retries` is unset, which `whenNonNull()` used to mask via its NPE-safe supplier.

The other items in #145 aren't Boot 4 blockers:
- Jackson 2 is deprecated on Boot 4, not removed
- Jackson 3 migration must start in [openfga/java-sdk](https://github.com/openfga/java-sdk); `ApiClient` takes a `com.fasterxml.jackson.databind.ObjectMapper`.

Verified `./gradlew compileJava` against `springBootVersion=3.4.3` and `4.0.2`.