### PR TITLE
feat: add OpenFGA Testcontainers service connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,35 @@ public HttpClient.Builder httpClientBuilder() {
 }
 ```
 
+## Testing with Testcontainers
+
+The starter ships a Spring Boot [`@ServiceConnection`](https://docs.spring.io/spring-boot/reference/testing/testcontainers.html#testing.testcontainers.service-connections)
+for OpenFGA. When the optional `org.springframework.boot:spring-boot-testcontainers` and
+`org.testcontainers:openfga` dependencies are on the test classpath, an `OpenFGAContainer` annotated
+with `@ServiceConnection` is automatically mapped into the Spring environment, so no `openfga.api-url`
+property is required in tests:
+
+```java
+@SpringBootTest
+@Testcontainers
+class MyOpenFgaTests {
+
+    @Container
+    @ServiceConnection
+    static OpenFGAContainer openfga = new OpenFGAContainer("openfga/openfga:latest");
+
+    @Autowired
+    OpenFgaClient fgaClient;
+
+    // ...
+}
+```
+
+The container's HTTP endpoint is supplied to the auto-configured `OpenFgaClient` via an
+`OpenFgaConnectionDetails` bean. Defining your own `OpenFgaConnectionDetails` bean (or the standard
+`openfga.api-url` property) continues to work and takes precedence when no service connection is
+present.
+
 ## Contributing
 
 ### Issues

--- a/README.md
+++ b/README.md
@@ -365,12 +365,12 @@ property is required in tests:
 
 ```java
 @SpringBootTest
-@Testcontainers
+@Testcontainers(disabledWithoutDocker = true)
 class MyOpenFgaTests {
 
     @Container
     @ServiceConnection
-    static OpenFGAContainer openfga = new OpenFGAContainer("openfga/openfga:latest");
+    static OpenFGAContainer openfga = new OpenFGAContainer("openfga/openfga:v1.4.3");
 
     @Autowired
     OpenFgaClient fgaClient;

--- a/build.gradle
+++ b/build.gradle
@@ -49,10 +49,18 @@ dependencies {
     compileOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     compileOnly "org.openapitools:jackson-databind-nullable:${jacksonDatabindNullableVersion}"
 
+    // Optional Testcontainers @ServiceConnection support. Only needed when consumers opt in to
+    // Testcontainers in their tests; the connection-details factory is skipped if these are absent.
+    compileOnly 'org.springframework.boot:spring-boot-testcontainers'
+    compileOnly 'org.testcontainers:openfga'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.hamcrest:hamcrest'
     testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:openfga'
 }
 
 test {

--- a/src/main/java/dev/openfga/autoconfigure/ConditionalOnFgaProperties.java
+++ b/src/main/java/dev/openfga/autoconfigure/ConditionalOnFgaProperties.java
@@ -5,15 +5,37 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Conditional;
 
 /**
- * Conditional that checks if the OpenFGA API URL is set. If it is, the
- * {@link OpenFgaClient} bean will be created.
+ * Conditional that activates the OpenFGA beans when a connection to OpenFGA can be resolved, either
+ * because the {@code openfga.api-url} property is set or because an {@link OpenFgaConnectionDetails}
+ * bean (for example, one contributed by a Testcontainers {@code @ServiceConnection}) is present.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
-@ConditionalOnProperty(name = {"openfga.api-url"})
 @ConditionalOnClass(OpenFgaClient.class)
-public @interface ConditionalOnFgaProperties {}
+@Conditional(ConditionalOnFgaProperties.FgaConnectionCondition.class)
+public @interface ConditionalOnFgaProperties {
+
+    /**
+     * Matches when either the {@code openfga.api-url} property is set or an
+     * {@link OpenFgaConnectionDetails} bean is available.
+     */
+    class FgaConnectionCondition extends AnyNestedCondition {
+
+        FgaConnectionCondition() {
+            super(ConfigurationPhase.REGISTER_BEAN);
+        }
+
+        @ConditionalOnProperty(name = "openfga.api-url")
+        static class ApiUrlProperty {}
+
+        @ConditionalOnBean(OpenFgaConnectionDetails.class)
+        static class ConnectionDetailsBean {}
+    }
+}

--- a/src/main/java/dev/openfga/autoconfigure/OpenFgaAutoConfiguration.java
+++ b/src/main/java/dev/openfga/autoconfigure/OpenFgaAutoConfiguration.java
@@ -29,8 +29,10 @@ import org.springframework.context.annotation.Bean;
 /**
  * Configures an {@code openFgaClient} and {@code openFga} beans based
  * on configuration values. The beans will only be created if the
- * {@link OpenFgaClient} is present on the classpath, and the
- * {@code openfga.api-url} is specified.
+ * {@link OpenFgaClient} is present on the classpath and either the
+ * {@code openfga.api-url} property is specified or an
+ * {@link OpenFgaConnectionDetails} bean is present (for example, one
+ * contributed by a Testcontainers {@code @ServiceConnection}).
  */
 @AutoConfiguration
 @ConditionalOnFgaProperties

--- a/src/main/java/dev/openfga/autoconfigure/OpenFgaAutoConfiguration.java
+++ b/src/main/java/dev/openfga/autoconfigure/OpenFgaAutoConfiguration.java
@@ -38,21 +38,37 @@ import org.springframework.context.annotation.Bean;
 public class OpenFgaAutoConfiguration {
 
     /**
-     * Configures the OpenFGA client with the provided properties.
+     * Provides {@link OpenFgaConnectionDetails} sourced from the configuration properties, unless a
+     * {@link OpenFgaConnectionDetails} bean (for example, one contributed by a Testcontainers
+     * {@code @ServiceConnection}) is already present.
      *
      * @param openFgaProperties the configuration properties for OpenFGA
+     * @return the properties-based {@link OpenFgaConnectionDetails} bean
+     */
+    @Bean
+    @ConditionalOnMissingBean(OpenFgaConnectionDetails.class)
+    public OpenFgaConnectionDetails openFgaConnectionDetails(OpenFgaProperties openFgaProperties) {
+        return openFgaProperties::getApiUrl;
+    }
+
+    /**
+     * Configures the OpenFGA client with the provided properties and connection details.
+     *
+     * @param openFgaProperties the configuration properties for OpenFGA
+     * @param connectionDetails the resolved {@link OpenFgaConnectionDetails}
      * @return the configured {@link ClientConfiguration} bean
      */
     @Bean
     @ConditionalOnMissingBean
-    public ClientConfiguration fgaConfig(OpenFgaProperties openFgaProperties) {
+    public ClientConfiguration fgaConfig(
+            OpenFgaProperties openFgaProperties, OpenFgaConnectionDetails connectionDetails) {
         var clientConfiguration = new ClientConfiguration();
         var map = PropertyMapper.get();
         map.from(openFgaProperties::getCredentials)
                 .when(Objects::nonNull)
                 .as(OpenFgaAutoConfiguration::toCredentials)
                 .to(clientConfiguration::credentials);
-        map.from(openFgaProperties::getApiUrl).whenHasText().to(clientConfiguration::apiUrl);
+        map.from(connectionDetails::getApiUrl).whenHasText().to(clientConfiguration::apiUrl);
         map.from(openFgaProperties::getStoreId).whenHasText().to(clientConfiguration::storeId);
         map.from(openFgaProperties::getAuthorizationModelId)
                 .whenHasText()

--- a/src/main/java/dev/openfga/autoconfigure/OpenFgaConnectionDetails.java
+++ b/src/main/java/dev/openfga/autoconfigure/OpenFgaConnectionDetails.java
@@ -1,0 +1,20 @@
+package dev.openfga.autoconfigure;
+
+import org.springframework.boot.autoconfigure.service.connection.ConnectionDetails;
+
+/**
+ * Details required to connect to an OpenFGA instance.
+ *
+ * <p>By default these are sourced from the {@code openfga.*} configuration properties, but a
+ * {@link ConnectionDetails} bean (for example, one contributed by a Testcontainers
+ * {@code @ServiceConnection}) takes precedence when present.
+ */
+public interface OpenFgaConnectionDetails extends ConnectionDetails {
+
+    /**
+     * Returns the URL of the OpenFGA instance.
+     *
+     * @return the API URL
+     */
+    String getApiUrl();
+}

--- a/src/main/java/dev/openfga/autoconfigure/OpenFgaContainerConnectionDetailsFactory.java
+++ b/src/main/java/dev/openfga/autoconfigure/OpenFgaContainerConnectionDetailsFactory.java
@@ -1,0 +1,33 @@
+package dev.openfga.autoconfigure;
+
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
+import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+import org.testcontainers.openfga.OpenFGAContainer;
+
+/**
+ * {@link ContainerConnectionDetailsFactory} that produces {@link OpenFgaConnectionDetails} for an
+ * {@link OpenFGAContainer} annotated with
+ * {@link org.springframework.boot.testcontainers.service.connection.ServiceConnection @ServiceConnection}.
+ */
+class OpenFgaContainerConnectionDetailsFactory
+        extends ContainerConnectionDetailsFactory<OpenFGAContainer, OpenFgaConnectionDetails> {
+
+    @Override
+    protected OpenFgaConnectionDetails getContainerConnectionDetails(
+            ContainerConnectionSource<OpenFGAContainer> source) {
+        return new OpenFgaContainerConnectionDetails(source);
+    }
+
+    private static final class OpenFgaContainerConnectionDetails extends ContainerConnectionDetails<OpenFGAContainer>
+            implements OpenFgaConnectionDetails {
+
+        private OpenFgaContainerConnectionDetails(ContainerConnectionSource<OpenFGAContainer> source) {
+            super(source);
+        }
+
+        @Override
+        public String getApiUrl() {
+            return getContainer().getHttpEndpoint();
+        }
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.service.connection.ConnectionDetailsFactory=\
+dev.openfga.autoconfigure.OpenFgaContainerConnectionDetailsFactory

--- a/src/test/java/dev/openfga/autoconfigure/OpenFgaAutoConfigurationTests.java
+++ b/src/test/java/dev/openfga/autoconfigure/OpenFgaAutoConfigurationTests.java
@@ -69,6 +69,30 @@ class OpenFgaAutoConfigurationTests {
     }
 
     @Test
+    void connectionDetailsBeanActivatesBeansAndSuppliesApiUrl() {
+        contextRunner
+                .withBean(OpenFgaConnectionDetails.class, () -> () -> "https://from-connection-details")
+                .withConfiguration(AutoConfigurations.of(OpenFgaAutoConfiguration.class))
+                .run(context -> {
+                    assertThat(context.containsBean("fgaClient"), is(true));
+                    ClientConfiguration config = (ClientConfiguration) context.getBean("fgaConfig");
+                    assertThat(config.getApiUrl(), is("https://from-connection-details"));
+                });
+    }
+
+    @Test
+    void connectionDetailsBeanTakesPrecedenceOverApiUrlProperty() {
+        contextRunner
+                .withPropertyValues("openfga.api-url=https://from-property")
+                .withBean(OpenFgaConnectionDetails.class, () -> () -> "https://from-connection-details")
+                .withConfiguration(AutoConfigurations.of(OpenFgaAutoConfiguration.class))
+                .run(context -> {
+                    ClientConfiguration config = (ClientConfiguration) context.getBean("fgaConfig");
+                    assertThat(config.getApiUrl(), is("https://from-connection-details"));
+                });
+    }
+
+    @Test
     void beanConfiguredForNoAuthorization() {
         contextRunner
                 .withPropertyValues(

--- a/src/test/java/dev/openfga/autoconfigure/OpenFgaServiceConnectionTests.java
+++ b/src/test/java/dev/openfga/autoconfigure/OpenFgaServiceConnectionTests.java
@@ -1,0 +1,51 @@
+package dev.openfga.autoconfigure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.openfga.sdk.api.client.OpenFgaClient;
+import dev.openfga.sdk.api.configuration.ClientConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.openfga.OpenFGAContainer;
+
+/**
+ * Verifies that a Testcontainers {@code @ServiceConnection} OpenFGA container is auto-mapped into
+ * the Spring environment and consumed by {@link OpenFgaAutoConfiguration}.
+ *
+ * <p>The whole class is skipped when Docker is unavailable, so it does not hard-fail in CI
+ * environments without a Docker daemon.
+ */
+@SpringBootTest
+@Testcontainers(disabledWithoutDocker = true)
+class OpenFgaServiceConnectionTests {
+
+    @Container
+    @ServiceConnection
+    static OpenFGAContainer openfga = new OpenFGAContainer("openfga/openfga:v1.4.3");
+
+    @Autowired
+    OpenFgaConnectionDetails connectionDetails;
+
+    @Autowired
+    ClientConfiguration clientConfiguration;
+
+    @Autowired
+    OpenFgaClient openFgaClient;
+
+    @Test
+    void connectionDetailsAreResolvedFromContainer() {
+        assertThat(connectionDetails.getApiUrl()).isEqualTo(openfga.getHttpEndpoint());
+        assertThat(clientConfiguration.getApiUrl()).isEqualTo(openfga.getHttpEndpoint());
+        assertThat(openFgaClient).isNotNull();
+    }
+
+    @SpringBootConfiguration
+    @ImportAutoConfiguration(OpenFgaAutoConfiguration.class)
+    static class TestConfig {}
+}


### PR DESCRIPTION
Adds a Testcontainers `@ServiceConnection` for OpenFGA, so a running container is mapped into the Spring environment with no `openfga.api-url` needed in tests.

Standard Boot pattern: an `OpenFgaConnectionDetails` interface plus a `ContainerConnectionDetailsFactory`. The auto-config now reads the URL from the connection-details bean and falls back to the property, so existing config still works and takes precedence when there's no service connection. Testcontainers stays optional (`compileOnly`).

Closes #58.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Testcontainers-based connectivity so OpenFGA can be wired automatically in tests.
  * Introduced a connection-details abstraction that lets the app use either a configured API URL or a container-provided endpoint.

* **Documentation**
  * Expanded the README with a new testing guide and sample Spring Boot Testcontainers setup.

* **Bug Fixes**
  * Improved configuration precedence so an explicit connection-details bean can override the default API URL when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->