### PR TITLE
chore(deps): bump org.springframework.boot from 3.4.3 to 3.4.13

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 jacksonDatabindNullableVersion=0.2.6
 openfgaSdkVersion=0.9.4
-springBootVersion=3.4.3
+springBootVersion=3.4.13
 springDependencyManagementVersion=1.1.7


### PR DESCRIPTION
## Summary

- Bumps the Spring Boot version used to compile and test the library from **3.4.3** to **3.4.13** (latest in the 3.4.x line)
- The example servlet app was already on the latest 3.5.x (3.5.15) and required no changes

## Background

The library pins its Spring Boot version to the **minimum supported version** it compiles against, giving downstream users flexibility to run any compatible Spring Boot version. Keeping this pin up to date within a minor version ensures we pick up all bug fixes and security patches while maintaining the same compatibility guarantee.

The 3.4.x patch releases (3.4.4 – 3.4.13) contain no breaking API changes — patch releases are strictly bug and security fixes. The Spring Boot APIs used by this library (`@AutoConfiguration`, `@ConfigurationProperties`, `ConditionalOn*`, `PropertyMapper`, `ApplicationContextRunner`, `spring-boot-starter-security`) are unaffected by any of the 3.4.x or 3.5.x breaking changes documented in the Spring Boot release notes.

## Changes

| File | Change |
|------|--------|
| `gradle.properties` | `springBootVersion` 3.4.3 → 3.4.13 |

## Compatibility

No compatibility concerns:
- **3.4.3 → 3.4.13**: patch-only bump, no API changes
- The library's public API and auto-configuration behaviour are unchanged
- Downstream users on any Spring Boot 3.4.x or 3.5.x version are unaffected

## Test plan

- [ ] CI build passes with Spring Boot 3.4.13
- [ ] All existing unit and integration tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Spring Boot version to a newer patch release, which may include stability improvements and security fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->