### PR TITLE
chore(ci): add missing x-release-please-version markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ It can be used with the following:
 * Gradle (Groovy)
 
 ```groovy
-implementation 'dev.openfga:openfga-spring-boot-starter:0.3.1'
+implementation 'dev.openfga:openfga-spring-boot-starter:0.3.1' // x-release-please-version
 ```
 
 * Gradle (Kotlin)
 
 ```kotlin
-implementation("dev.openfga:openfga-spring-boot-starter:0.3.1")
+implementation("dev.openfga:openfga-spring-boot-starter:0.3.1") // x-release-please-version
 ```
 
 * Apache Maven
@@ -52,7 +52,7 @@ implementation("dev.openfga:openfga-spring-boot-starter:0.3.1")
 <dependency>
     <groupId>dev.openfga</groupId>
     <artifactId>openfga-spring-boot-starter</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.1</version> <!-- x-release-please-version -->
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply from: 'publish.gradle'
 
 group = 'dev.openfga'
-version = '0.3.1'
+version = '0.3.1' // x-release-please-version
 
 java {
     sourceCompatibility = 17

--- a/examples/servlet/build.gradle
+++ b/examples/servlet/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-    implementation 'dev.openfga:openfga-spring-boot-starter:0.3.1'
+    implementation 'dev.openfga:openfga-spring-boot-starter:0.3.1' // x-release-please-version
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
     testImplementation 'org.testcontainers:openfga:1.21.4'

--- a/publish.gradle
+++ b/publish.gradle
@@ -6,7 +6,7 @@ publishing {
             pom {
                 group = 'dev.openfga'
                 name = 'openfga-spring-boot-starter'
-                version = '0.3.1'
+                version = '0.3.1' // x-release-please-version
                 description = 'This is the Spring Boot Starter for OpenFGA.'
                 url = 'https://openfga.dev'
                 licenses {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,6 +25,7 @@
       ],
       "extra-files": [
         { "type": "generic", "path": "build.gradle" },
+        { "type": "generic", "path": "publish.gradle" },
         { "type": "generic", "path": "README.md" },
         { "type": "generic", "path": "examples/servlet/build.gradle" }
       ]


### PR DESCRIPTION


The extra-files entries use the generic updater, which only rewrites versions on lines annotated with x-release-please-version. None of the files carried the annotation, so build.gradle stayed at 0.3.1 while the manifest and tag advanced to 0.3.2 -- causing the publish job to re-upload 0.3.1 and fail with an 'already exists' error.

Add the markers to build.gradle, publish.gradle, README.md, and the servlet example, and register publish.gradle in extra-files. Matches the openfga/java-sdk configuration.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release-management annotations across project version references and installation examples.
  * Expanded automated release tracking to include publishing metadata.
  * No user-facing version changes; the current version remains 0.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->