### PR TITLE
chore(ci): use common workflows for undraft/verify tag

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Checks
@@ -36,9 +39,40 @@ jobs:
       - name: Run Gradle check task
         run: ./gradlew check --continue
 
-  publish-maven-central:
+  verify-version:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [ test ]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify versions match
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          MANIFEST_VERSION=$(jq -r '.["."]' .release-please-manifest.json)
+          GRADLE_VERSION=$(grep 'x-release-please-version' build.gradle | grep -oP "'\K[^']+")
+          PUBLISH_VERSION=$(grep 'x-release-please-version' publish.gradle | grep -oP "'\K[^']+")
+
+          echo "Tag: $TAG_VERSION | Manifest: $MANIFEST_VERSION | build.gradle: $GRADLE_VERSION | publish.gradle: $PUBLISH_VERSION"
+
+          if [[ "$TAG_VERSION" != "$MANIFEST_VERSION" ]]; then
+            echo "ERROR: Tag version does not match manifest version"
+            exit 1
+          fi
+          if [[ "$GRADLE_VERSION" != "$MANIFEST_VERSION" ]]; then
+            echo "ERROR: build.gradle version does not match manifest version"
+            exit 1
+          fi
+          if [[ "$PUBLISH_VERSION" != "$MANIFEST_VERSION" ]]; then
+            echo "ERROR: publish.gradle version does not match manifest version"
+            exit 1
+          fi
+          echo "All versions verified: $TAG_VERSION"
+
+  publish-maven-central:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [ verify-version ]
     runs-on: ubuntu-latest
 
     permissions:
@@ -71,7 +105,7 @@ jobs:
 
   publish-github-packages:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [ test ]
+    needs: [ verify-version ]
     runs-on: ubuntu-latest
 
     permissions:
@@ -101,22 +135,9 @@ jobs:
           ORG_GRADLE_PROJECT_SIGNINGKEY: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_SIGNINGPASSWORD: ${{ secrets.GPG_PASSPHRASE }}
 
-  create-release:
+  undraft-release:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [ publish-maven-central, publish-github-packages ]
-    runs-on: ubuntu-latest
-
     permissions:
       contents: write
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - uses: Roang-zero1/github-create-release-action@57eb9bdce7a964e48788b9e78b5ac766cb684803 # v3.0.1
-        with:
-          version_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+
-          prerelease_regex: ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+-(alpha|beta|preview)\.[[:digit:]]+$
-          changelog_file: CHANGELOG.md
-          create_draft: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: openfga/.github/.github/workflows/undraft-release.yml@835baf31562809ad9eb884c73efc5b79318f700f # pin@main

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ spotless {
     }
     flexmark {
         target "*.md"
+        targetExclude "CHANGELOG.md"
         flexmark()
     }
 }


### PR DESCRIPTION


- Add a verify-version job that fails the tag build if the tag, manifest, build.gradle, and publish.gradle versions disagree -- catching the kind of drift that caused the 0.3.1/0.3.2 publish failure.
- Replace the Roang-zero1 create-release job (which produced duplicate untagged-* drafts) with the shared openfga/.github undraft-release.yml reusable, which undrafts the tag-keyed release created by release-please after a successful publish.
- Gate publish jobs on verify-version and add a top-level read permission.
- Exclude CHANGELOG.md from spotless flexmark so the machine-generated changelog no longer fails formatting checks on release PRs.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated version verification before package publishing.
  * Updated release handling to safely publish and undraft releases through a pinned workflow.
* **Bug Fixes**
  * Prevented changelog formatting checks from modifying or processing `CHANGELOG.md`.
* **Security**
  * Restricted workflow permissions to the minimum required access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->