### PR TITLE
fix: bump openfga-sdk to 0.9.11 and use transactions() API

### DIFF
--- a/examples/servlet/src/main/java/dev/openfga/example/config/LoadData.java
+++ b/examples/servlet/src/main/java/dev/openfga/example/config/LoadData.java
@@ -79,7 +79,7 @@ public class LoadData {
                                         .relation("viewer")
                                         ._object("document:1"))),
                         new ClientWriteOptions()
-                                .disableTransactions(true)
+                                .transactions(false)
                                 .authorizationModelId(authorizationModel.getAuthorizationModelId()))
                 .get();
         logger.debug("Done Writing Tuples");

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 jacksonDatabindNullableVersion=0.2.6
-openfgaSdkVersion=0.9.4
+openfgaSdkVersion=0.9.11
 springBootVersion=3.4.13
 springDependencyManagementVersion=1.1.7

--- a/src/test/java/dev/openfga/autoconfigure/OpenFgaInitializerTest.java
+++ b/src/test/java/dev/openfga/autoconfigure/OpenFgaInitializerTest.java
@@ -1,7 +1,6 @@
 package dev.openfga.autoconfigure;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -155,7 +154,7 @@ class OpenFgaInitializerTest {
         var writeOptionsCaptor = ArgumentCaptor.forClass(ClientWriteOptions.class);
         verify(fgaClient).write(any(), writeOptionsCaptor.capture());
         assertEquals("01H...", writeOptionsCaptor.getValue().getAuthorizationModelId());
-        assertFalse(writeOptionsCaptor.getValue().disableTransactions());
+        assertTrue(writeOptionsCaptor.getValue().isTransactionsEnabled());
         var readOptionsCaptor = ArgumentCaptor.forClass(ClientReadOptions.class);
         verify(fgaClient).read(any(), readOptionsCaptor.capture());
         assertEquals(


### PR DESCRIPTION
## Summary

Bumps the `openfga-sdk` dependency from 0.9.4 to 0.9.11, the first published release that includes the affirmative `transactions(boolean)` / `isTransactionsEnabled()` API (java-sdk #352), and migrates the starter's own usages off the double-negative `disableTransactions`.

The dependency bump is the precondition #186 was blocked on: the servlet example builds against a published Maven artifact, and no release before 0.9.11 carried the new method.

## Changes

- `gradle.properties`: `openfgaSdkVersion` 0.9.4 to 0.9.11.
- `examples/servlet/.../LoadData.java`: `.disableTransactions(true)` to `.transactions(false)`.
- `src/test/.../OpenFgaInitializerTest.java`: `assertFalse(options.disableTransactions())` to `assertTrue(options.isTransactionsEnabled())`, and dropped the now-unused `assertFalse` import.

Behavior is unchanged. `transactions(false)` is exactly equivalent to the prior `disableTransactions(true)`, and `isTransactionsEnabled()` is the inverse of `disableTransactions()`.

## Scope note

#186 named only the servlet example. The initializer test (`OpenFgaInitializerTest.java:158`) also called `disableTransactions()`; it arrived with the initial-model-loading feature (#171) after #186 was filed. It is migrated here so the starter is fully on the new API and stays warning-free once java-sdk deprecates the old methods, since java-sdk's deprecation work does not touch this repo's tests.

## Verification

The 0.9.11 artifact on Maven Central was confirmed to expose `transactions(boolean)` and `isTransactionsEnabled()` (verified against the published jar). A local Gradle build could not run here because dependency resolution is routed through a private mirror that returns auth errors in this environment; CI performs the authoritative build and test against public repositories.

Closes #186


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OpenFGA write configuration to use the current transaction setting, ensuring example data loading remains compatible with the latest SDK.
  * Updated transactional initialization checks to reflect the current configuration behavior.

* **Chores**
  * Upgraded the OpenFGA SDK to version 0.9.11.
  * Removed an unused test import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->