### PR TITLE
fix: correct version-verification regex in verify-version job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,8 +51,10 @@ jobs:
         run: |
           TAG_VERSION="${GITHUB_REF#refs/tags/v}"
           MANIFEST_VERSION=$(jq -r '.["."]' .release-please-manifest.json)
-          GRADLE_VERSION=$(grep 'x-release-please-version' build.gradle | grep -oP "'\K[^']+")
-          PUBLISH_VERSION=$(grep 'x-release-please-version' publish.gradle | grep -oP "'\K[^']+")
+          # The (?=') lookahead requires a closing quote, so the trailing
+          # marker comment is not captured as a second match.
+          GRADLE_VERSION=$(grep 'x-release-please-version' build.gradle | grep -oP "'\K[^']+(?=')")
+          PUBLISH_VERSION=$(grep 'x-release-please-version' publish.gradle | grep -oP "'\K[^']+(?=')")
 
           echo "Tag: $TAG_VERSION | Manifest: $MANIFEST_VERSION | build.gradle: $GRADLE_VERSION | publish.gradle: $PUBLISH_VERSION"
 


### PR DESCRIPTION
The `grep -oP "'\K[^']+"` pattern matched twice on lines like `version = '0.4.0' // x-release-please-version`: once for the version and again for the trailing comment, since the closing quote was treated as the start of a second match. That made GRADLE_VERSION a two-line value and failed the comparison against the manifest, blocking the v0.4.0 publish.

Add a `(?=')` lookahead so a closing quote is required, matching the fix already applied in openfga/java-sdk.

<!-- Thanks for opening a PR! Here are some quick tips:
If this is your first time contributing, [read our Contributing Guidelines](https://github.com/openfga/.github/blob/main/CONTRIBUTING.md) to learn how to create an acceptable PR for this repo.
By submitting a PR to this repository, you agree to the terms within the [OpenFGA Code of Conduct](https://github.com/openfga/.github/blob/main/CODE_OF_CONDUCT.md)

If your PR is under active development, please submit it as a "draft". Once it's ready, open it up for review.
-->

<!-- Provide a brief summary of the changes -->

## Description
<!-- Provide a detailed description of the changes -->
#### What problem is being solved?

#### How is it being solved?

#### What changes are made to solve it?

## References
<!--
Provide a list of any applicable references here (GitHub Issue, [OpenFGA RFC](https://github.com/openfga/rfcs), other PRs, etc..). We prefer an accompanying issue for all non-trivial PRs.

When referencing links, follow these examples:
* closes https://github.com/openfga/{repo}/issues/{issue_number}
* reverts https://github.com/openfga/{repo}/pull/{pr_number}
* followup https://github.com/openfga/{repo}/pull/{pr_number}
* blocked by https://github.com/openfga/{repo}/pull/{pr_number}
-->

## Review Checklist
- [ ] I have clicked on ["allow edits by maintainers"](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added documentation for new/changed functionality in this PR or in a PR to [openfga.dev](https://github.com/openfga/openfga.dev) [Provide a link to any relevant PRs in the references section above]
- [ ] The correct base branch is being used, if not `main`
- [ ] I have added tests to validate that the change in functionality is working as expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version validation to correctly identify the declared version without including trailing comments or markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->